### PR TITLE
Decouple quest item parsing from sync registration

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -661,10 +661,11 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             Map<String, String> macroSnapshot = questsLoader.createMacroSnapshot();
 
             this.serverScheduler.runTaskAsynchronously(() -> {
+                BukkitQuestsLoader.QuestItemParsingResult questItemParsingResult = questsLoader.parseQuestItems(itemsFolder);
                 BukkitQuestsLoader.QuestParsingResult parsingResult = questsLoader.parseQuestFiles(questsFolder, macroSnapshot);
 
                 this.serverScheduler.runTask(() -> {
-                    questsLoader.loadQuestItems(itemsFolder);
+                    questsLoader.registerQuestItems(questItemParsingResult);
                     configProblems = questsLoader.applyParsedQuests(parsingResult);
 
                     for (TaskType taskType : taskTypeManager.getTaskTypes()) {


### PR DESCRIPTION
## Summary
- parse quest item configuration files asynchronously during reload
- register parsed quest items on the main thread so Bukkit API access remains thread-safe
- keep quest reload synchronous work lightweight to avoid watchdog stalls

## Testing
- ./gradlew :bukkit:check

------
https://chatgpt.com/codex/tasks/task_b_68d6ee90c3708327977428103a454384